### PR TITLE
Add `$scope` to rich feature values

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ PennantTool::make()
 
 ### Rich Feature Values
 
-In order to configure rich values Nova would need to depend on a class-based feature and utilize `options()` method:
+In order to configure rich values Nova would need to depend on a class-based feature and utilize `options(mixed $scope)` method:
 
 ```diff
 namespace App\Features;
@@ -86,7 +86,7 @@ class UserTier
 {
     public $name = 'user-tier';
 
-+   public function options(): array 
++   public function options(mixed $scope): array 
 +   {
 +      return ['solo', 'pro'];
 +   }

--- a/src/FeatureTableRow.php
+++ b/src/FeatureTableRow.php
@@ -23,7 +23,8 @@ class FeatureTableRow implements JsonSerializable
      */
     public function __construct(
         public string $feature,
-        public bool|string $value
+        public bool|string $value,
+        public mixed $scope,
     ) {
         //
     }
@@ -47,7 +48,7 @@ class FeatureTableRow implements JsonSerializable
             'type' => $type,
             'options' => match (true) {
                 is_bool($this->value) => true,
-                $type === 'class' && method_exists($instance, 'options') => $instance->options(),
+                $type === 'class' && method_exists($instance, 'options') => $instance->options($this->scope),
                 default => false,
             },
         ];

--- a/src/Http/Controllers/FeaturesController.php
+++ b/src/Http/Controllers/FeaturesController.php
@@ -18,6 +18,7 @@ class FeaturesController
             ->map(fn ($value, $feature) => FeatureTableRow::make(
                 feature: $feature,
                 value: $value,
+                scope: $request->findModelOrFail(),
             ))->values();
     }
 }

--- a/tests/Feature/FeatureTableRowTest.php
+++ b/tests/Feature/FeatureTableRowTest.php
@@ -4,7 +4,7 @@ use App\Features\UserRole;
 use Laravel\Nova\PennantTool\FeatureTableRow;
 
 it('can be resolved', function () {
-    $row = new FeatureTableRow('new-api', true);
+    $row = new FeatureTableRow('new-api', true, 'taylor@laravel.com');
 
     expect($row->meta())->toBe([
         'type' => 'closure',
@@ -23,7 +23,7 @@ it('can be resolved', function () {
 });
 
 it('can resolve class based feature', function () {
-    $row = new FeatureTableRow(UserRole::class, 'administrator');
+    $row = new FeatureTableRow(UserRole::class, 'administrator', 'taylor@laravel.com');
 
     expect($row->meta())->toBe([
         'type' => 'class',
@@ -42,7 +42,7 @@ it('can resolve class based feature', function () {
 });
 
 it('can resolve class based feature with options', function () {
-    $row = new FeatureTableRow('purchase-button', 'tart-orange');
+    $row = new FeatureTableRow('purchase-button', 'tart-orange', 'taylor@laravel.com');
 
     expect($row->meta())->toBe([
         'type' => 'class',

--- a/workbench/app/Features/PurchaseButton.php
+++ b/workbench/app/Features/PurchaseButton.php
@@ -18,7 +18,7 @@ class PurchaseButton
      */
     public function resolve(mixed $scope): mixed
     {
-        return Arr::random($this->options());
+        return Arr::random($this->options($scope));
     }
 
     /**
@@ -26,7 +26,7 @@ class PurchaseButton
      *
      * @return array<int, string>
      */
-    public function options(): array
+    public function options(mixed $scope): array
     {
         return [
             'blue-sapphire',


### PR DESCRIPTION
The feature class's `options` method signature should be passed the current `$scope`. It is possible the options available to a given scope are different depending on some dynamic data.